### PR TITLE
We should rebuild kaem-optional-seed early in the bootstrap

### DIFF
--- a/AMD64/.gitignore
+++ b/AMD64/.gitignore
@@ -21,6 +21,7 @@ hex2_linker.M1
 hold
 kaem-footer.M1
 kaem.M1
+kaem-0
 temp1
 mes-footer.M1
 mes.M1

--- a/AMD64/mescc-tools-mini-kaem.kaem
+++ b/AMD64/mescc-tools-mini-kaem.kaem
@@ -25,15 +25,6 @@
 # Warning all binaries prior to the use of blood-elf will not be readable by
 # Objdump, you may need to use ndism or gdb to view the assembly in the binary.
 
-
-
-###############################################
-# Phase-0 Build hex0 from bootstrapped binary #
-###############################################
-../../bootstrap-seeds/POSIX/AMD64/hex0-seed hex0_AMD64.hex0 hex0
-# hex0 should have the exact same checksum as hex0-seed as they are both supposed
-# to be built from hex0_amd64.hex0 and by definition must be identical
-
 #################################
 # Phase-1 Build hex1 from hex0  #
 #################################

--- a/AMD64/mescc-tools-seed-kaem.kaem
+++ b/AMD64/mescc-tools-seed-kaem.kaem
@@ -1,0 +1,41 @@
+#! /usr/bin/env bash
+# Mes --- Maxwell Equations of Software
+# Copyright © 2017 Jan Nieuwenhuizen <janneke@gnu.org>
+# Copyright © 2017 Jeremiah Orians
+#
+# This file is part of Mes.
+#
+# Mes is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or (at
+# your option) any later version.
+#
+# Mes is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Mes.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+# Can also be run by kaem or any other shell of your personal choice
+# To run in kaem simply: kaem --verbose --strict
+# Warning all binaries prior to the use of blood-elf will not be readable by
+# Objdump, you may need to use ndism or gdb to view the assembly in the binary.
+
+
+
+###############################################
+# Phase-0 Build hex0 from bootstrapped binary #
+###############################################
+../../bootstrap-seeds/POSIX/AMD64/hex0-seed hex0_AMD64.hex0 hex0
+# hex0 should have the exact same checksum as hex0-seed as they are both supposed
+# to be built from hex0_amd64.hex0 and by definition must be identical
+
+#########################################
+# Phase-0b Build minimal kaem from hex0 #
+#########################################
+./hex0 ../../bootstrap-seeds/kaem-optional-seed.hex0 kaem-0
+# for checksum validation reasons

--- a/x86/.gitignore
+++ b/x86/.gitignore
@@ -21,6 +21,7 @@ hex2_linker.M1
 hold
 kaem-footer.M1
 kaem.M1
+kaem-0
 temp1
 mes-footer.M1
 mes.M1

--- a/x86/kaem.run
+++ b/x86/kaem.run
@@ -27,7 +27,8 @@
 # Phase 0-12 Build hex0 from bootstrapped binary #
 ##################################################
 
-../../bootstrap-seeds/kaem-optional-seed mescc-tools-mini-kaem.kaem
+../../bootstrap-seeds/kaem-optional-seed mescc-tools-seed-kaem.kaem
+./kaem-0 mescc-tools-mini-kaem.kaem
 ../bin/kaem --verbose --strict -f mescc-tools-full-kaem.kaem
 
 ############################################

--- a/x86/mescc-tools-mini-kaem.kaem
+++ b/x86/mescc-tools-mini-kaem.kaem
@@ -26,14 +26,6 @@
 # Objdump, you may need to use ndism or gdb to view the assembly in the binary.
 
 
-
-###############################################
-# Phase-0 Build hex0 from bootstrapped binary #
-###############################################
-../../bootstrap-seeds/POSIX/x86/hex0-seed hex0_x86.hex0 hex0
-# hex0 should have the exact same checksum as hex0-seed as they are both supposed
-# to be built from hex0_x86.hex0 and by definition must be identical
-
 #################################
 # Phase-1 Build hex1 from hex0  #
 #################################

--- a/x86/mescc-tools-seed-kaem.kaem
+++ b/x86/mescc-tools-seed-kaem.kaem
@@ -22,17 +22,20 @@
 
 # Can also be run by kaem or any other shell of your personal choice
 # To run in kaem simply: kaem --verbose --strict
+# Warning all binaries prior to the use of blood-elf will not be readable by
+# Objdump, you may need to use ndism or gdb to view the assembly in the binary.
 
-##################################################
-# Phase 0-12 Build hex0 from bootstrapped binary #
-##################################################
 
-../../bootstrap-seeds/kaem-optional-seed mescc-tools-seed-kaem.kaem
-./kaem-0 mescc-tools-mini-kaem.kaem
-../bin/kaem --verbose --strict -f mescc-tools-full-kaem.kaem
 
-############################################
-# Phase-13 Build Mes-M2 from M2-Planet     #
-############################################
+###############################################
+# Phase-0 Build hex0 from bootstrapped binary #
+###############################################
+../../bootstrap-seeds/POSIX/x86/hex0-seed hex0_x86.hex0 hex0
+# hex0 should have the exact same checksum as hex0-seed as they are both supposed
+# to be built from hex0_x86.hex0 and by definition must be identical
 
-../bin/kaem --verbose --strict --file mes-m2.kaem
+#########################################
+# Phase-0b Build minimal kaem from hex0 #
+#########################################
+./hex0 ../../bootstrap-seeds/kaem-optional-seed.hex0 kaem-0
+# for checksum validation reasons


### PR DESCRIPTION
Now that we have a hex0 version we should rebuild it as we do with the other hex0 seed.